### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ DerivedData
 Pods/
 *.orig
 
+.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WebViewWarmUper",
+    platforms: [.iOS(.v10)],
+    products: [
+        .library(
+            name: "WebViewWarmUper",
+            targets: ["WebViewWarmUper"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "WebViewWarmUper",
+            dependencies: [], 
+            path: "WebViewWarmUper/Classes"),
+        .testTarget(
+            name: "WebViewWarmUperTests",
+            dependencies: ["WebViewWarmUper"]),
+    ]
+)

--- a/Tests/WebViewWarmUperTests/WebViewWarmUperTests.swift
+++ b/Tests/WebViewWarmUperTests/WebViewWarmUperTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+@testable import WebViewWarmUper
+
+final class WebViewWarmUperTests: XCTestCase {
+    func testExample() throws {
+    }
+}


### PR DESCRIPTION
I left supported iOS versoin at 10 as that is what's listed in pod version. This throws a warning in SPM as support for 10 is deprecated. Bump it to 11 to silence the warning.